### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Fetch source code
+        uses: actions/checkout@v2
+
+      - name: Set up nix
+        uses: cachix/install-nix-action@v13
+        with:
+          extra_nix_config: |
+            substituters = https://cache.nixos.org/ https://cache.holo.host/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ=
+
+      - name: Cache nix with Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          # this reads from the cache at https://holochain.cachix.org
+          # you can set up your own free cache via https://cachix.org
+          name: holochain
+          # if an auth token is set up, nix will be cached to your cachix cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      # - name: Inspect nix.conf
+      #   run: cat ~/.config/nix/nix.conf
+
+      - name: Prepare Nix environment
+        run: nix-shell --command "echo Completed"
+
+      - run: nix-shell --pure --run 'CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown'
+      - run: nix-shell --pure --run 'hc dna pack workdir/dna'
+      - run: nix-shell --pure --run 'hc app pack workdir/happ'
+      - run: nix-shell --pure --run 'cd tests && npm install && npm test'


### PR DESCRIPTION
This PR:

- Runs tests in Github Actions
- Sets up nix using caches:
  - cache.holo.host
  - my public cachix cache
- Add hints for setting up your own cachix cache 

Passing build:

https://github.com/core-network/holochain-dna-build-tutorial/runs/2811931905?check_suite_focus=true

Note that setting up nix packages is now 1 minute, was 36 minutes before adding Cachix (even with cache.holo.host cache in place).