### PR TITLE
fix hash mismatch error

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ let
     holochainVersion = {
      rev = "363af6d8af8d18e4616f6aa56ad4d1f0fabaafb7";
      sha256 = "0ssjhang6zljs0zrph998zj7582rf0vdb45p855awa7fmzpd4kfa";
-     cargoSha256 = "15g0ndb64hcfqyqn5pb01vnipg4gxlm0p543z2vr407dgrwfwvhw";
+     cargoSha256 = "0y72lm5b0fl9anb2z9pcx1i3shqdlckz04zx3phc084hbzpig4cq";
      bins = {
        holochain = "holochain";
        hc = "hc";


### PR DESCRIPTION
I hit this: 
hash mismatch in fixed-output derivation '/nix/store/v97983fx4zhfaa71azax02c4vhj74dhq-holochain-vendor.tar.gz':
  wanted: sha256:15g0ndb64hcfqyqn5pb01vnipg4gxlm0p543z2vr407dgrwfwvhw
  got:    sha256:0y72lm5b0fl9anb2z9pcx1i3shqdlckz04zx3phc084hbzpig4cq

so this just updates